### PR TITLE
add Docker container for kmersGWAS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.10
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /app
+
+# install Python3 and R
+RUN apt update
+RUN apt install -y python3
+RUN apt install -y dirmngr gnupg apt-transport-https ca-certificates software-properties-common
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+#RUN sudo add-apt-repository -y 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
+RUN apt install -y r-base
+RUN apt install -y python2
+RUN apt install -y kmc
+RUN apt install -y gemma
+RUN apt install -y wget
+RUN R -e 'install.packages("MASS")'
+RUN R -e 'install.packages("mvnpermute")'
+RUN R -e 'install.packages("matrixcalc")'
+
+RUN wget https://github.com/voichek/kmersGWAS/releases/download/v0.2-beta/v0_2_beta.zip
+RUN unzip v0_2_beta.zip
+ENV PATH="/app/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Details on how to create a *k*-mers table and how to run GWA can be found in [th
   + Mvnpermute
   + matrixcalc
 
+**NOTE**: Instead of installing all the dependencies, you can alternatively build a docker container with all the dependencies as well as the scripts for kmersGWAS pre-installed in `/app` directory as outlined in the [Dockerfile](Dockerfile). An existing Docker image exists at [DockerHub](https://hub.docker.com/repository/docker/tayabsoomro/kmer-gwas)
 
 ## Examples:
 In the examples directory there are two examples of how to use the library:


### PR DESCRIPTION
This PR adds the recipe for creating a Docker container with all the dependencies as well as the kmersGWAS pre-installed to allow the user to only focus on their biological problem instead of being bogged down by software dependencies/installation-related issues. In addition, it also points to an already existing [Docker image container](https://hub.docker.com/repository/docker/tayabsoomro/kmer-gwas) which can be pulled and used instantly.

I believe that the addition of a Docker container is going to increase the usability of this tool.

cheers,
Tayab